### PR TITLE
Add CI workflow for tests and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential clang-format libfmt-dev libgtest-dev
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Run tests
+        run: |
+          cd build
+          ctest --output-on-failure
+      - name: Check code format
+        run: |
+          FILES=$(git ls-files '*.cpp' '*.hpp' '*.h')
+          if [ -n "$FILES" ]; then
+            clang-format -i $FILES
+            git diff --exit-code
+          fi
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test the project
- run clang-format in CI

## Testing
- `cmake -S . -B build && cmake --build build && cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_685ac380cb848329b3c2cb7dacb8a9b0