### PR TITLE
Switch library to C++17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,15 @@ target_include_directories(wide_integer INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_compile_features(wide_integer INTERFACE cxx_std_20)
+target_compile_features(wide_integer INTERFACE cxx_std_17)
 
 enable_testing()
 include(GoogleTest)
 add_executable(wide_integer_test
     tests/wide_integer_test.cpp
 )
+
+target_compile_features(wide_integer_test PRIVATE cxx_std_17)
 
 target_link_libraries(wide_integer_test PRIVATE wide_integer fmt::fmt GTest::gtest_main)
 
@@ -31,6 +33,15 @@ target_include_directories(wide_integer_cxx11_test PRIVATE
 target_compile_features(wide_integer_cxx11_test PRIVATE cxx_std_11)
 target_link_libraries(wide_integer_cxx11_test PRIVATE fmt::fmt GTest::gtest_main)
 gtest_discover_tests(wide_integer_cxx11_test)
+
+add_executable(perf_cxx17
+    bench/performance.cpp
+)
+target_include_directories(perf_cxx17 PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+target_compile_features(perf_cxx17 PRIVATE cxx_std_17)
+target_link_libraries(perf_cxx17 PRIVATE fmt::fmt)
 
 add_executable(perf_cxx20
     bench/performance.cpp

--- a/include/wide_integer/endian_compat.h
+++ b/include/wide_integer/endian_compat.h
@@ -1,29 +1,30 @@
 #pragma once
 
 #if __cplusplus >= 202002L
-#include <bit>
+#    include <bit>
 #else
-#include <cstdint>
-namespace std {
+#    include <cstdint>
+namespace std
+{
 enum class endian
 {
-#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)
+#    if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)
     little = __ORDER_LITTLE_ENDIAN__,
     big = __ORDER_BIG_ENDIAN__,
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#        if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     native = little
-#else
+#        else
     native = big
-#endif
-#else
+#        endif
+#    else
     little = 0,
     big = 1,
-#ifdef _WIN32
+#        ifdef _WIN32
     native = little
-#else
+#        else
     native = little
-#endif
-#endif
+#        endif
+#    endif
 };
 } // namespace std
 #endif

--- a/include/wide_integer/endian_compat.h
+++ b/include/wide_integer/endian_compat.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#if __cplusplus >= 202002L
+#include <bit>
+#else
+#include <cstdint>
+namespace std {
+enum class endian
+{
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)
+    little = __ORDER_LITTLE_ENDIAN__,
+    big = __ORDER_BIG_ENDIAN__,
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    native = little
+#else
+    native = big
+#endif
+#else
+    little = 0,
+    big = 1,
+#ifdef _WIN32
+    native = little
+#else
+    native = little
+#endif
+#endif
+};
+} // namespace std
+#endif

--- a/include/wide_integer/wide_integer.h
+++ b/include/wide_integer/wide_integer.h
@@ -22,7 +22,6 @@
  * without express or implied warranty.
  */
 
-#include "endian_compat.h"
 #include <cassert>
 #include <cfloat>
 #include <cmath>
@@ -35,12 +34,13 @@
 #include <tuple>
 #include <type_traits>
 #include <fmt/format.h>
+#include "endian_compat.h"
 
 #if __cplusplus < 202002L
 namespace std
 {
-    template <class T>
-    using remove_cvref_t = typename remove_cv<typename remove_reference<T>::type>::type;
+template <class T>
+using remove_cvref_t = typename remove_cv<typename remove_reference<T>::type>::type;
 }
 #endif
 

--- a/include/wide_integer/wide_integer.h
+++ b/include/wide_integer/wide_integer.h
@@ -22,7 +22,7 @@
  * without express or implied warranty.
  */
 
-#include <bit>
+#include "endian_compat.h"
 #include <cassert>
 #include <cfloat>
 #include <cmath>
@@ -35,6 +35,14 @@
 #include <tuple>
 #include <type_traits>
 #include <fmt/format.h>
+
+#if __cplusplus < 202002L
+namespace std
+{
+    template <class T>
+    using remove_cvref_t = typename remove_cv<typename remove_reference<T>::type>::type;
+}
+#endif
 
 // NOLINTBEGIN(*)
 
@@ -120,8 +128,7 @@ public:
 
     constexpr explicit operator bool() const noexcept;
 
-    template <typename T>
-    requires(std::is_arithmetic_v<T>)
+    template <typename T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
     constexpr operator T() const noexcept;
 
     constexpr operator long double() const noexcept;
@@ -218,14 +225,12 @@ constexpr integer<Bits, Signed> operator<<(const integer<Bits, Signed> & lhs, in
 template <size_t Bits, typename Signed>
 constexpr integer<Bits, Signed> operator>>(const integer<Bits, Signed> & lhs, int n) noexcept;
 
-template <size_t Bits, typename Signed, typename Int>
-requires(!std::is_same_v<Int, int>)
+template <size_t Bits, typename Signed, typename Int, std::enable_if_t<!std::is_same_v<Int, int>, int> = 0>
 constexpr integer<Bits, Signed> operator<<(const integer<Bits, Signed> & lhs, Int n) noexcept
 {
     return lhs << int(n);
 }
-template <size_t Bits, typename Signed, typename Int>
-requires(!std::is_same_v<Int, int>)
+template <size_t Bits, typename Signed, typename Int, std::enable_if_t<!std::is_same_v<Int, int>, int> = 0>
 constexpr integer<Bits, Signed> operator>>(const integer<Bits, Signed> & lhs, Int n) noexcept
 {
     return lhs >> int(n);
@@ -343,8 +348,7 @@ struct ConstructBitInt256<unsigned>
 
 /// Converts a 256-bit wide integer to Clang's built-in 256-bit integer representation.
 /// The source and target types have the same byte order.
-template <size_t Bits, typename Signed>
-requires(Bits == 256)
+template <size_t Bits, typename Signed, std::enable_if_t<Bits == 256, int> = 0>
 constexpr const auto & toBitInt256(const wide::integer<Bits, Signed> & n)
 {
     using T = ConstructBitInt256<Signed>::Type;
@@ -353,8 +357,7 @@ constexpr const auto & toBitInt256(const wide::integer<Bits, Signed> & n)
 
 /// Converts a Clang's built-in 256-bit integer representation to a 256-bit wide integer.
 /// The source and target types have the same byte order.
-template <typename T>
-requires(std::is_same_v<T, BitInt256> || std::is_same_v<T, BitUInt256>)
+template <typename T, std::enable_if_t<std::is_same_v<T, BitInt256> || std::is_same_v<T, BitUInt256>, int> = 0>
 constexpr const auto & fromBitInt256(const T & n)
 {
     using Signed = std::conditional_t<std::is_same_v<T, BitInt256>, signed, unsigned>;
@@ -1023,7 +1026,7 @@ public:
         {
             if constexpr (use_BitInt256)
             {
-                if constexpr (!std::same_as<T, integer<Bits, Signed>>)
+                if constexpr (!std::is_same_v<T, integer<Bits, Signed>>)
                 {
                     auto new_rhs = static_cast<integer<Bits, Signed>>(rhs);
                     return fromBitInt256(toBitInt256(lhs) + toBitInt256(new_rhs));
@@ -1054,7 +1057,7 @@ public:
         {
             if constexpr (use_BitInt256)
             {
-                if constexpr (!std::same_as<T, integer<Bits, Signed>>)
+                if constexpr (!std::is_same_v<T, integer<Bits, Signed>>)
                 {
                     auto new_rhs = static_cast<integer<Bits, Signed>>(rhs);
                     return fromBitInt256(toBitInt256(lhs) - toBitInt256(new_rhs));
@@ -1085,7 +1088,7 @@ public:
         {
             if constexpr (use_BitInt256)
             {
-                if constexpr (!std::same_as<T, integer<Bits, Signed>>)
+                if constexpr (!std::is_same_v<T, integer<Bits, Signed>>)
                 {
                     auto new_rhs = static_cast<integer<Bits, Signed>>(rhs);
                     return fromBitInt256(toBitInt256(lhs) * toBitInt256(new_rhs));
@@ -1306,7 +1309,7 @@ public:
         {
             if constexpr (use_BitInt256)
             {
-                if constexpr (!std::same_as<T, integer<Bits, Signed>>)
+                if constexpr (!std::is_same_v<T, integer<Bits, Signed>>)
                 {
                     auto new_rhs = static_cast<integer<Bits, Signed>>(rhs);
                     return fromBitInt256(toBitInt256(lhs) / toBitInt256(new_rhs));
@@ -1339,7 +1342,7 @@ public:
         {
             if constexpr (use_BitInt256)
             {
-                if constexpr (!std::same_as<T, integer<Bits, signed>>)
+                if constexpr (!std::is_same_v<T, integer<Bits, signed>>)
                 {
                     auto new_rhs = static_cast<integer<Bits, Signed>>(rhs);
                     return fromBitInt256(toBitInt256(lhs) % toBitInt256(new_rhs));
@@ -1641,8 +1644,7 @@ constexpr integer<Bits, Signed>::operator bool() const noexcept
 }
 
 template <size_t Bits, typename Signed>
-template <class T>
-requires(std::is_arithmetic_v<T>)
+template <class T, std::enable_if_t<std::is_arithmetic_v<T>, int>>
 constexpr integer<Bits, Signed>::operator T() const noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer);


### PR DESCRIPTION
## Summary
- add small `std::endian` fallback for pre-C++20
- replace concepts with SFINAE in the wide integer header
- adjust CMake to build with C++17 and rename perf target
- add perf target for C++20 to compare builds

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`
- `./perf_cxx11`
- `./perf_cxx17`
- `./perf_cxx20`


------
https://chatgpt.com/codex/tasks/task_e_685b79134da88329979095181a531309