### PR TITLE
Add release benchmarks and drop CXX20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 find_package(fmt REQUIRED)
 find_package(GTest REQUIRED)
+find_package(benchmark REQUIRED)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+endif()
 
 add_library(wide_integer INTERFACE)
 
@@ -43,16 +48,9 @@ target_include_directories(perf_cxx17 PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 target_compile_features(perf_cxx17 PRIVATE cxx_std_17)
-target_link_libraries(perf_cxx17 PRIVATE fmt::fmt)
+target_link_libraries(perf_cxx17 PRIVATE fmt::fmt benchmark::benchmark)
+target_compile_options(perf_cxx17 PRIVATE -O3 -DNDEBUG)
 
-add_executable(perf_cxx20
-    bench/performance.cpp
-)
-target_include_directories(perf_cxx20 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-target_compile_features(perf_cxx20 PRIVATE cxx_std_20)
-target_link_libraries(perf_cxx20 PRIVATE fmt::fmt)
 
 add_executable(perf_cxx11
     bench/performance.cpp
@@ -62,4 +60,5 @@ target_include_directories(perf_cxx11 PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 target_compile_features(perf_cxx11 PRIVATE cxx_std_11)
-target_link_libraries(perf_cxx11 PRIVATE fmt::fmt)
+target_link_libraries(perf_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
+target_compile_options(perf_cxx11 PRIVATE -O3 -DNDEBUG)

--- a/bench/performance.cpp
+++ b/bench/performance.cpp
@@ -1,5 +1,4 @@
-#include <chrono>
-#include <fmt/core.h>
+#include <benchmark/benchmark.h>
 
 #ifdef USE_CXX11_HEADER
 #    include <wide_integer/wide_integer_cxx11.h>
@@ -7,21 +6,55 @@
 #    include <wide_integer/wide_integer.h>
 #endif
 
-int main()
+using WInt = wide::integer<256, unsigned>;
+
+static void BM_Addition(benchmark::State & state)
 {
-    using WInt = wide::integer<256, unsigned>;
-    WInt result = 0;
     WInt a = 123456789;
     WInt b = 987654321;
-
-    auto start = std::chrono::high_resolution_clock::now();
-    for (int i = 0; i < 100000; ++i)
+    for (auto _ : state)
     {
-        result += a * b;
-        result -= a;
+        WInt c = a + b;
+        benchmark::DoNotOptimize(c);
     }
-    auto end = std::chrono::high_resolution_clock::now();
-    fmt::print("{}\n", wide::to_string(result));
-    fmt::print("{}\n", std::chrono::duration<double, std::milli>(end - start).count());
-    return 0;
 }
+
+static void BM_Subtraction(benchmark::State & state)
+{
+    WInt a = 987654321;
+    WInt b = 123456789;
+    for (auto _ : state)
+    {
+        WInt c = a - b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+static void BM_Multiplication(benchmark::State & state)
+{
+    WInt a = 123456789;
+    WInt b = 987654321;
+    for (auto _ : state)
+    {
+        WInt c = a * b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+static void BM_Division(benchmark::State & state)
+{
+    WInt a = 987654321;
+    WInt b = 123456;
+    for (auto _ : state)
+    {
+        WInt c = a / b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+BENCHMARK(BM_Addition);
+BENCHMARK(BM_Subtraction);
+BENCHMARK(BM_Multiplication);
+BENCHMARK(BM_Division);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
## Summary
- default build type is Release
- remove `perf_cxx20` target
- compile benchmark targets with `-O3 -DNDEBUG`
- drop unused fmt include

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/perf_cxx17 --benchmark_min_time=0.1s`
- `./build/perf_cxx11 --benchmark_min_time=0.1s`
- `./build/wide_integer_test`
- `./build/wide_integer_cxx11_test`


------
https://chatgpt.com/codex/tasks/task_e_685baad5916c832981141b225d0b24c7