### PR TITLE
Add coverage workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,20 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake build-essential clang-format libfmt-dev libgtest-dev libbenchmark-dev
+          sudo apt-get install -y cmake build-essential clang-format libfmt-dev libgtest-dev libbenchmark-dev lcov
       - name: Configure
-        run: cmake -S . -B build
+        run: cmake -S . -B build -DENABLE_COVERAGE=ON
       - name: Build
-        run: cmake --build build --config Release
+        run: cmake --build build --config Debug
       - name: Run tests
         run: |
           cd build
           ctest --output-on-failure
+      - name: Generate coverage
+        run: |
+          lcov --capture --directory build --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' --output-file coverage.info
+          lcov --list coverage.info
       - name: Check code format
         run: |
           FILES=$(git ls-files '*.cpp' '*.hpp' '*.h')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,16 @@ project(wide_integer LANGUAGES CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
+option(ENABLE_COVERAGE "Enable coverage reporting" OFF)
+
+if(ENABLE_COVERAGE)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        add_compile_options(-O0 -g --coverage)
+        add_link_options(--coverage)
+    endif()
+endif()
+
 find_package(fmt REQUIRED)
 find_package(GTest REQUIRED)
 find_package(benchmark REQUIRED)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # wide_integer
 wide integer implementation in CH
+
+## Code Coverage
+
+To generate coverage locally, configure the project with the `ENABLE_COVERAGE` option
+and build the tests:
+
+```bash
+cmake -S . -B build -DENABLE_COVERAGE=ON
+cmake --build build --config Debug
+cd build && ctest
+```
+
+After running the tests, coverage information can be collected with `lcov`:
+
+```bash
+lcov --capture --directory build --output-file coverage.info
+lcov --remove coverage.info '/usr/*' --output-file coverage.info
+lcov --list coverage.info
+```


### PR DESCRIPTION
## Summary
- enable optional coverage flags in CMake
- document how to run coverage locally
- update CI workflow to run coverage on each push

## Testing
- `cmake -S . -B build -DENABLE_COVERAGE=ON`
- `cmake --build build --config Debug`
- `ctest --output-on-failure`
- `lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch`
- `lcov --remove coverage.info '/usr/*' --output-file coverage.info`

------
https://chatgpt.com/codex/tasks/task_e_685c0c16877c832994da68f01e31a316