### PR TITLE
Increase tests for wide_integer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,9 @@ add_executable(wide_integer_test
 )
 
 target_compile_features(wide_integer_test PRIVATE cxx_std_17)
-target_compile_options(wide_integer_test PRIVATE -O3 -DNDEBUG)
+if(NOT ENABLE_COVERAGE)
+    target_compile_options(wide_integer_test PRIVATE -O3 -DNDEBUG)
+endif()
 
 target_link_libraries(wide_integer_test PRIVATE wide_integer fmt::fmt GTest::gtest_main)
 
@@ -49,7 +51,9 @@ target_include_directories(wide_integer_cxx11_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 target_compile_features(wide_integer_cxx11_test PRIVATE cxx_std_11)
-target_compile_options(wide_integer_cxx11_test PRIVATE -O3 -DNDEBUG)
+if(NOT ENABLE_COVERAGE)
+    target_compile_options(wide_integer_cxx11_test PRIVATE -O3 -DNDEBUG)
+endif()
 target_link_libraries(wide_integer_cxx11_test PRIVATE fmt::fmt GTest::gtest_main)
 gtest_discover_tests(wide_integer_cxx11_test)
 
@@ -57,7 +61,9 @@ add_executable(wide_integer_conversion_test
     tests/wide_integer_conversion_test.cpp
 )
 target_compile_features(wide_integer_conversion_test PRIVATE cxx_std_17)
-target_compile_options(wide_integer_conversion_test PRIVATE -O3 -DNDEBUG)
+if(NOT ENABLE_COVERAGE)
+    target_compile_options(wide_integer_conversion_test PRIVATE -O3 -DNDEBUG)
+endif()
 target_link_libraries(wide_integer_conversion_test PRIVATE wide_integer fmt::fmt GTest::gtest_main)
 gtest_discover_tests(wide_integer_conversion_test)
 
@@ -68,9 +74,12 @@ target_include_directories(wide_integer_conversion_cxx11_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 target_compile_features(wide_integer_conversion_cxx11_test PRIVATE cxx_std_11)
-target_compile_options(wide_integer_conversion_cxx11_test PRIVATE -O3 -DNDEBUG)
+if(NOT ENABLE_COVERAGE)
+    target_compile_options(wide_integer_conversion_cxx11_test PRIVATE -O3 -DNDEBUG)
+endif()
 target_link_libraries(wide_integer_conversion_cxx11_test PRIVATE fmt::fmt GTest::gtest_main)
 gtest_discover_tests(wide_integer_conversion_cxx11_test)
+
 
 add_executable(perf_cxx17
     bench/performance.cpp

--- a/tests/wide_integer_test.cpp
+++ b/tests/wide_integer_test.cpp
@@ -230,3 +230,69 @@ TEST(WideInteger512, Comparison)
     EXPECT_TRUE(a != b);
     EXPECT_TRUE(a >= a);
 }
+
+TEST(WideIntegerExtra, CompoundOperators)
+{
+    wide::integer<128, unsigned> v = 1;
+    v += 2;
+    EXPECT_EQ(v, 3U);
+    v *= 5;
+    EXPECT_EQ(v, 15U);
+    v -= 5;
+    EXPECT_EQ(v, 10U);
+    v /= 2;
+    EXPECT_EQ(v, 5U);
+    v %= 2U;
+    EXPECT_EQ(v, 1U);
+    v |= wide::integer<128, unsigned>(2U);
+    EXPECT_EQ(v, 3U);
+    v &= wide::integer<128, unsigned>(1U);
+    EXPECT_EQ(v, 1U);
+    v ^= wide::integer<128, unsigned>(3U);
+    EXPECT_EQ(v, 2U);
+    v <<= 4;
+    EXPECT_EQ(v, 32U);
+    v >>= 1;
+    EXPECT_EQ(v, 16U);
+}
+
+TEST(WideIntegerExtra, IncDecAndBool)
+{
+    wide::integer<128, unsigned> v = 0;
+    EXPECT_FALSE(static_cast<bool>(v));
+    ++v;
+    EXPECT_EQ(v, 1U);
+    v++;
+    EXPECT_EQ(v, 2U);
+    --v;
+    EXPECT_EQ(v, 1U);
+    v--;
+    EXPECT_EQ(v, 0U);
+    EXPECT_FALSE(static_cast<bool>(v));
+}
+
+TEST(WideIntegerExtra, UnaryAndToString)
+{
+    wide::integer<128, signed> a = -1;
+    auto b = -a;
+    EXPECT_EQ(b, 1);
+    auto c = +b;
+    EXPECT_EQ(c, 1);
+    auto d = ~wide::integer<128, unsigned>(0);
+    EXPECT_EQ(d, (wide::integer<128, unsigned>(-1)));
+
+    std::ostringstream oss;
+    oss << wide::to_string(b);
+    EXPECT_EQ(oss.str(), "1");
+
+    EXPECT_EQ(fmt::format("{}", b), "1");
+}
+
+TEST(WideIntegerExtra, FloatConversion)
+{
+    wide::integer<128, unsigned> v = 123;
+    double d = static_cast<double>(v);
+    EXPECT_NEAR(d, 123.0, 1e-9);
+    float f = static_cast<float>(v);
+    EXPECT_NEAR(f, 123.0f, 1e-6f);
+}


### PR DESCRIPTION
## Summary
- add wide integer extra tests into main test file
- adjust CMake so coverage builds compile without optimizations
- revert cxx11 extra tests that failed to compile

## Testing
- `cmake -S . -B build -DENABLE_COVERAGE=ON`
- `cmake --build build --target wide_integer_test wide_integer_cxx11_test wide_integer_conversion_test wide_integer_conversion_cxx11_test --config Debug`
- `ctest --output-on-failure`
- `lcov --capture --directory . --output-file coverage.info --ignore-errors mismatch`
- `lcov --remove coverage.info '/usr/*' '*/tests/*' --output-file coverage.info`

------
https://chatgpt.com/codex/tasks/task_e_685c13c5c16c8329a861aab14f6705c5