### PR TITLE
Add implicit conversion to builtin __int128

### DIFF
--- a/include/wide_integer/wide_integer.h
+++ b/include/wide_integer/wide_integer.h
@@ -134,6 +134,8 @@ public:
     constexpr operator long double() const noexcept;
     constexpr operator double() const noexcept;
     constexpr operator float() const noexcept;
+    constexpr operator __int128() const noexcept;
+    constexpr operator unsigned __int128() const noexcept;
 
     struct _impl;
 
@@ -1716,6 +1718,25 @@ template <size_t Bits, typename Signed>
 constexpr integer<Bits, Signed>::operator float() const noexcept
 {
     return static_cast<float>(static_cast<long double>(*this));
+}
+template <size_t Bits, typename Signed>
+constexpr integer<Bits, Signed>::operator __int128() const noexcept
+{
+    unsigned __int128 res{};
+    for (unsigned i = 0; i < _impl::item_count && i < (sizeof(__int128) + sizeof(base_type) - 1) / sizeof(base_type); ++i)
+        res += static_cast<unsigned __int128>(items[_impl::little(i)])
+            << (sizeof(base_type) * 8 * i); // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
+    return static_cast<__int128>(res);
+}
+
+template <size_t Bits, typename Signed>
+constexpr integer<Bits, Signed>::operator unsigned __int128() const noexcept
+{
+    unsigned __int128 res{};
+    for (unsigned i = 0; i < _impl::item_count && i < (sizeof(unsigned __int128) + sizeof(base_type) - 1) / sizeof(base_type); ++i)
+        res += static_cast<unsigned __int128>(items[_impl::little(i)])
+            << (sizeof(base_type) * 8 * i); // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
+    return res;
 }
 
 // Unary operators

--- a/tests/wide_integer_test.cpp
+++ b/tests/wide_integer_test.cpp
@@ -57,6 +57,7 @@ TEST(WideIntegerBasic, Bitwise)
     auto d = a | b;
     EXPECT_EQ(wide::to_string(d), "14");
 }
+
 TEST(WideIntegerAdditional, ShiftRight)
 {
     wide::integer<128, unsigned> a = wide::integer<128, unsigned>(1) << 127;
@@ -331,7 +332,7 @@ TEST(WideIntegerInt128, UnsignedRoundtrip)
 {
     unsigned __int128 value = (static_cast<unsigned __int128>(1) << 80) + 42;
     wide::integer<256, unsigned> w = value;
-    unsigned __int128 back = static_cast<unsigned __int128>(w);
+    unsigned __int128 back = w;
     EXPECT_EQ(back, value);
 }
 
@@ -339,7 +340,7 @@ TEST(WideIntegerInt128, SignedRoundtrip)
 {
     __int128 value = -((static_cast<__int128>(1) << 90) + 77);
     wide::integer<256, signed> w = value;
-    __int128 back = static_cast<__int128>(w);
+    __int128 back = w;
     EXPECT_EQ(back, value);
 }
 


### PR DESCRIPTION
## Summary
- add conversion operators from wide integers to signed and unsigned builtin 128-bit integers
- exercise implicit `__int128` round-trips in tests

## Testing
- `cmake -S . -B build`
- `cmake --build build --target wide_integer_test wide_integer_cxx11_test`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_689aad2fa6488329b090f741cdb87efa