### PR TITLE
fix: support ostream printing for wide integer

### DIFF
--- a/include/wide_integer/wide_integer.h
+++ b/include/wide_integer/wide_integer.h
@@ -30,6 +30,7 @@
 #include <functional>
 #include <initializer_list>
 #include <limits>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -1994,10 +1995,10 @@ namespace wide
 
 template <size_t Bits, typename Signed>
 std::string to_string(const integer<Bits, Signed> & n);
-}
 
 template <size_t Bits, typename Signed>
-std::ostream & operator<<(std::ostream & out, const wide::integer<Bits, Signed> & value);
+std::ostream & operator<<(std::ostream & out, const integer<Bits, Signed> & value);
+}
 
 /// See https://fmt.dev/latest/api.html#formatting-user-defined-types
 template <size_t Bits, typename Signed>
@@ -2053,10 +2054,10 @@ inline std::string to_string(const integer<Bits, Signed> & n)
     std::reverse(res.begin(), res.end());
     return res;
 }
-}
 
 template <size_t Bits, typename Signed>
-std::ostream & operator<<(std::ostream & out, const wide::integer<Bits, Signed> & value)
+std::ostream & operator<<(std::ostream & out, const integer<Bits, Signed> & value)
 {
     return out << to_string(value);
+}
 }

--- a/include/wide_integer/wide_integer_cxx11.h
+++ b/include/wide_integer/wide_integer_cxx11.h
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <ostream>
 #include <string>
 #include <type_traits>
 #include <fmt/format.h>
@@ -19,6 +20,9 @@ using UInt256 = integer<256, unsigned>;
 
 template <size_t Bits, typename Signed>
 std::string to_string(const integer<Bits, Signed> & value);
+
+template <size_t Bits, typename Signed>
+std::ostream & operator<<(std::ostream & out, const integer<Bits, Signed> & value);
 
 namespace detail
 {
@@ -751,6 +755,12 @@ inline std::string to_string(const integer<Bits, Signed> & v)
     if (neg)
         res.insert(res.begin(), '-');
     return res;
+}
+
+template <size_t Bits, typename Signed>
+inline std::ostream & operator<<(std::ostream & out, const integer<Bits, Signed> & value)
+{
+    return out << to_string(value);
 }
 
 } // namespace wide


### PR DESCRIPTION
## Summary
- enable streaming printer for `wide::integer` by placing operator<< in the `wide` namespace
- add matching overload for the C++11 header

## Testing
- `cmake -S . -B build`
- `cmake --build build --target wide_integer_test`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a2a3e551488329ad324f15387b093d