### PR TITLE
Expand C++11 wide integer builtin operator support

### DIFF
--- a/include/wide_integer/wide_integer_cxx11.h
+++ b/include/wide_integer/wide_integer_cxx11.h
@@ -372,6 +372,20 @@ public:
         return rhs;
     }
 
+    template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+    friend integer operator+(integer lhs, T rhs) noexcept
+    {
+        lhs += integer(rhs);
+        return lhs;
+    }
+
+    template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+    friend integer operator+(T lhs, integer rhs) noexcept
+    {
+        rhs += integer(lhs);
+        return rhs;
+    }
+
     friend integer operator-(integer lhs, const integer & rhs) noexcept
     {
         lhs -= rhs;
@@ -391,10 +405,37 @@ public:
         return integer(lhs) - rhs;
     }
 
+    template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+    friend integer operator-(integer lhs, T rhs) noexcept
+    {
+        lhs -= integer(rhs);
+        return lhs;
+    }
+
+    template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+    friend integer operator-(T lhs, integer rhs) noexcept
+    {
+        return integer(lhs) - rhs;
+    }
+
     friend integer operator&(integer lhs, const integer & rhs) noexcept
     {
         lhs &= rhs;
         return lhs;
+    }
+
+    template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+    friend integer operator&(integer lhs, T rhs) noexcept
+    {
+        lhs &= integer(rhs);
+        return lhs;
+    }
+
+    template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+    friend integer operator&(T lhs, integer rhs) noexcept
+    {
+        rhs &= integer(lhs);
+        return rhs;
     }
 
     friend integer operator|(integer lhs, const integer & rhs) noexcept
@@ -403,10 +444,38 @@ public:
         return lhs;
     }
 
+    template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+    friend integer operator|(integer lhs, T rhs) noexcept
+    {
+        lhs |= integer(rhs);
+        return lhs;
+    }
+
+    template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+    friend integer operator|(T lhs, integer rhs) noexcept
+    {
+        rhs |= integer(lhs);
+        return rhs;
+    }
+
     friend integer operator^(integer lhs, const integer & rhs) noexcept
     {
         lhs ^= rhs;
         return lhs;
+    }
+
+    template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+    friend integer operator^(integer lhs, T rhs) noexcept
+    {
+        lhs ^= integer(rhs);
+        return lhs;
+    }
+
+    template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+    friend integer operator^(T lhs, integer rhs) noexcept
+    {
+        rhs ^= integer(lhs);
+        return rhs;
     }
 
     friend integer operator<<(integer lhs, int n) noexcept
@@ -484,6 +553,18 @@ public:
         return integer(lhs) * rhs;
     }
 
+    template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+    friend integer operator*(integer lhs, T rhs) noexcept
+    {
+        return lhs * integer(rhs);
+    }
+
+    template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+    friend integer operator*(T lhs, integer rhs) noexcept
+    {
+        return integer(lhs) * rhs;
+    }
+
     friend integer operator/(integer lhs, const integer & rhs) noexcept
     {
         integer result;
@@ -527,6 +608,18 @@ public:
         return integer(lhs) / rhs;
     }
 
+    template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+    friend integer operator/(integer lhs, T rhs) noexcept
+    {
+        return lhs / integer(rhs);
+    }
+
+    template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+    friend integer operator/(T lhs, integer rhs) noexcept
+    {
+        return integer(lhs) / rhs;
+    }
+
     template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
     friend integer operator%(integer lhs, T rhs) noexcept
     {
@@ -534,6 +627,18 @@ public:
     }
 
     template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+    friend integer operator%(T lhs, integer rhs) noexcept
+    {
+        return integer(lhs) % rhs;
+    }
+
+    template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+    friend integer operator%(integer lhs, T rhs) noexcept
+    {
+        return lhs % integer(rhs);
+    }
+
+    template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
     friend integer operator%(T lhs, integer rhs) noexcept
     {
         return integer(lhs) % rhs;

--- a/tests/wide_integer_test.cpp
+++ b/tests/wide_integer_test.cpp
@@ -609,3 +609,80 @@ TEST(WideIntegerInt128, Arithmetic)
     EXPECT_EQ(wide::to_string(d), "120");
     EXPECT_EQ(wide::to_string(e), "2000");
 }
+
+template <typename T>
+void test_integral_ops()
+{
+    using W = wide::integer<256, signed>;
+    const __int128 ai = 1000;
+    W a = ai;
+    T b = static_cast<T>(123);
+    __int128 bi = static_cast<__int128>(b);
+    EXPECT_EQ(a + b, W(ai + bi));
+    EXPECT_EQ(b + a, W(bi + ai));
+    EXPECT_EQ(a - b, W(ai - bi));
+    EXPECT_EQ(b - a, W(bi - ai));
+    EXPECT_EQ(a * b, W(ai * bi));
+    EXPECT_EQ(b * a, W(bi * ai));
+    EXPECT_EQ(a / b, W(ai / bi));
+    EXPECT_EQ(b / a, W(bi / ai));
+    EXPECT_EQ(a % b, W(ai % bi));
+    EXPECT_EQ(b % a, W(bi % ai));
+    EXPECT_EQ(a & b, W(ai & bi));
+    EXPECT_EQ(b & a, W(ai & bi));
+    EXPECT_EQ(a | b, W(ai | bi));
+    EXPECT_EQ(b | a, W(ai | bi));
+    EXPECT_EQ(a ^ b, W(ai ^ bi));
+    EXPECT_EQ(b ^ a, W(ai ^ bi));
+    EXPECT_TRUE(a > b);
+    EXPECT_TRUE(b < a);
+    EXPECT_TRUE(a >= b);
+    EXPECT_TRUE(b <= a);
+    EXPECT_TRUE(a != b);
+}
+
+template <typename T>
+void test_float_ops()
+{
+    using W = wide::integer<256, signed>;
+    const __int128 ai = 1000;
+    W a = ai;
+    T b = static_cast<T>(123.5);
+    __int128 bi = static_cast<__int128>(b);
+    EXPECT_EQ(a + b, W(ai + bi));
+    EXPECT_EQ(b + a, W(ai + bi));
+    EXPECT_EQ(a - b, W(ai - bi));
+    EXPECT_EQ(b - a, W(bi - ai));
+    EXPECT_EQ(a * b, W(ai * bi));
+    EXPECT_EQ(b * a, W(ai * bi));
+    EXPECT_EQ(a / b, W(ai / bi));
+    EXPECT_EQ(b / a, W(bi / ai));
+    EXPECT_EQ(a % b, W(ai % bi));
+    EXPECT_EQ(b % a, W(bi % ai));
+    EXPECT_TRUE(a > b);
+    EXPECT_TRUE(b < a);
+    EXPECT_TRUE(a >= b);
+    EXPECT_TRUE(b <= a);
+    EXPECT_TRUE(a != b);
+}
+TEST(WideIntegerBuiltin, IntegralTypes)
+{
+    test_integral_ops<int8_t>();
+    test_integral_ops<uint8_t>();
+    test_integral_ops<int16_t>();
+    test_integral_ops<uint16_t>();
+    test_integral_ops<int32_t>();
+    test_integral_ops<uint32_t>();
+    test_integral_ops<int64_t>();
+    test_integral_ops<uint64_t>();
+    test_integral_ops<__int128>();
+    test_integral_ops<unsigned __int128>();
+}
+
+#ifdef USE_CXX11_HEADER
+TEST(WideIntegerBuiltin, FloatingTypes)
+{
+    test_float_ops<float>();
+    test_float_ops<double>();
+}
+#endif


### PR DESCRIPTION
## Summary
- support arithmetic with floating-point values in C++11 wide integers
- allow bitwise ops with builtin integral types on C++11 wide integers
- add coverage for builtin integer and floating operations

## Testing
- `cmake --build build --target wide_integer_test wide_integer_cxx11_test`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a4716c70288329b0b6930ffccc4683