### PR TITLE
docs: improve README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # wide_integer
-wide integer implementation in CH
+A high-performance, header-only library extracted and refined from ClickHouse
+for working with fixed-width integers. It ensures that types like
+`wide::integer<256, true>` occupy exactly 256 bits, supports arithmetic and
+conversions with standard C++ integer types, and depends only on the `fmt`
+library for formatted output. The implementation targets C++17 while offering a
+slightly slower C++11-compatible variant.
 
 ## Performance
 


### PR DESCRIPTION
## Summary
- Expand opening paragraph to describe the library's ClickHouse origins, fixed-width guarantees, minimal dependencies and C++17 focus with C++11 fallback

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a493385a088329b35ee8cc5e433a15