### PR TITLE
docs: improve project introduction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # wide_integer
-wide integer implementation in CH
+An independent, header-only C++ library built on ClickHouse's wide integer work to implement high-performance fixed-width integers.
+
+- Provides separate C++11 and C++17 implementations to fit different project requirements
+- Guarantees that bit widths exactly match their definition (e.g., `wide::integer<256, unsigned>` is exactly 256 bits)
+- Supports arithmetic operations and conversions with standard C++ integer types
+- Depends only on `fmt` for formatted output
 
 ## Performance
 


### PR DESCRIPTION
## Summary
- Clarify README introduction to state the library is built on ClickHouse's wide integer work

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a4964bfd408329b7d3026b04f3be19