### PR TITLE
Use pkg-config to locate fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,12 @@ if(ENABLE_COVERAGE)
     endif()
 endif()
 
-find_package(fmt REQUIRED)
+find_package(fmt CONFIG QUIET)
+if(NOT fmt_FOUND)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(fmt REQUIRED IMPORTED_TARGET fmt)
+    add_library(fmt::fmt ALIAS PkgConfig::fmt)
+endif()
 find_package(GTest REQUIRED)
 find_package(benchmark REQUIRED)
 


### PR DESCRIPTION
## Summary
- Restore minimum CMake version to 3.10
- Fall back to pkg-config to link against system fmt when CMake config is missing

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a52aa14cbc83298dd31a4d1070aa16