### PR TITLE
Add __int128 conversion operators

### DIFF
--- a/include/wide_integer/wide_integer_cxx11.h
+++ b/include/wide_integer/wide_integer_cxx11.h
@@ -190,6 +190,22 @@ public:
             return static_cast<T>(value);
     }
 
+    operator __int128() const noexcept
+    {
+        unsigned __int128 value = 0;
+        for (size_t i = 0; i < limbs && i < (sizeof(__int128) + sizeof(limb_type) - 1) / sizeof(limb_type); ++i)
+            value |= static_cast<unsigned __int128>(data_[i]) << (i * 64);
+        return static_cast<__int128>(value);
+    }
+
+    operator unsigned __int128() const noexcept
+    {
+        unsigned __int128 value = 0;
+        for (size_t i = 0; i < limbs && i < (sizeof(unsigned __int128) + sizeof(limb_type) - 1) / sizeof(limb_type); ++i)
+            value |= static_cast<unsigned __int128>(data_[i]) << (i * 64);
+        return value;
+    }
+
     explicit operator long double() const noexcept
     {
         if (is_zero())

--- a/tests/wide_integer_test.cpp
+++ b/tests/wide_integer_test.cpp
@@ -610,6 +610,36 @@ TEST(WideIntegerInt128, Arithmetic)
     EXPECT_EQ(wide::to_string(e), "2000");
 }
 
+TEST(WideIntegerInt128, SignedToUnsignedConversion)
+{
+    wide::integer<256, signed> w = 123;
+    unsigned __int128 via_static = static_cast<unsigned __int128>(w);
+    unsigned __int128 via_implicit = w;
+    EXPECT_TRUE(via_static == static_cast<unsigned __int128>(123));
+    EXPECT_TRUE(via_implicit == static_cast<unsigned __int128>(123));
+
+    wide::integer<256, signed> negative = -1;
+    unsigned __int128 static_neg = static_cast<unsigned __int128>(negative);
+    unsigned __int128 implicit_neg = negative;
+    EXPECT_TRUE(static_neg == static_cast<unsigned __int128>(-1));
+    EXPECT_TRUE(implicit_neg == static_cast<unsigned __int128>(-1));
+}
+
+TEST(WideIntegerInt128, SignedConversion)
+{
+    wide::integer<256, signed> w = 123;
+    __int128 via_static = static_cast<__int128>(w);
+    __int128 via_implicit = w;
+    EXPECT_TRUE(via_static == static_cast<__int128>(123));
+    EXPECT_TRUE(via_implicit == static_cast<__int128>(123));
+
+    wide::integer<256, signed> negative = -1;
+    __int128 static_neg = static_cast<__int128>(negative);
+    __int128 implicit_neg = negative;
+    EXPECT_TRUE(static_neg == static_cast<__int128>(-1));
+    EXPECT_TRUE(implicit_neg == static_cast<__int128>(-1));
+}
+
 template <typename T>
 void test_integral_ops()
 {


### PR DESCRIPTION
## Summary
- support converting wide integers to signed and unsigned `__int128` in the C++11 implementation
- test conversions from 256-bit signed integers to both `__int128` and `unsigned __int128`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a53e3446788329a3cbb34ab370ff49