### PR TITLE
Add __int128 constructors for C++11 implementation

### DIFF
--- a/include/wide_integer/wide_integer_cxx11.h
+++ b/include/wide_integer/wide_integer_cxx11.h
@@ -144,6 +144,16 @@ public:
     {
     }
 
+    constexpr integer(__int128 v) noexcept
+        : integer(v, typename detail::make_index_sequence<limbs>::type())
+    {
+    }
+
+    constexpr integer(unsigned __int128 v) noexcept
+        : integer(v, typename detail::make_index_sequence<limbs>::type())
+    {
+    }
+
 private:
     template <typename T, size_t... I>
     constexpr integer(T v, detail::index_sequence<I...>) noexcept
@@ -168,6 +178,18 @@ public:
 
     template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
     integer & operator=(T v) noexcept
+    {
+        assign(v);
+        return *this;
+    }
+
+    integer & operator=(__int128 v) noexcept
+    {
+        assign(v);
+        return *this;
+    }
+
+    integer & operator=(unsigned __int128 v) noexcept
     {
         assign(v);
         return *this;

--- a/tests/wide_integer_test.cpp
+++ b/tests/wide_integer_test.cpp
@@ -318,6 +318,18 @@ TEST(WideIntegerConversion, Int128)
     EXPECT_EQ(static_cast<__int128>(a), v);
     EXPECT_TRUE(a == v);
     EXPECT_TRUE(v == a);
+
+    __int128 neg = -v;
+    wide::integer<256, signed> b = neg;
+    EXPECT_EQ(static_cast<__int128>(b), neg);
+    EXPECT_TRUE(b == neg);
+    EXPECT_TRUE(neg == b);
+
+    unsigned __int128 u = (static_cast<unsigned __int128>(1) << 100) + 123;
+    wide::integer<256, unsigned> c = u;
+    EXPECT_EQ(static_cast<unsigned __int128>(c), u);
+    EXPECT_TRUE(c == u);
+    EXPECT_TRUE(u == c);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- support constructing `integer` from signed and unsigned `__int128` values in C++11 implementation
- add tests covering signed and unsigned `__int128` construction

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e5e548188329bc7432d57cd721aa