### PR TITLE
Optimize cxx11 division performance

### DIFF
--- a/tests/wide_integer_test.cpp
+++ b/tests/wide_integer_test.cpp
@@ -760,3 +760,15 @@ TEST(WideIntegerDivision, NegativeOperands)
     check(-8, -2);
     check(-1, 2);
 }
+
+TEST(WideInteger256, Division)
+{
+    using W = wide::integer<256, unsigned>;
+    W a = (W{1} << 200) + 123456789ULL;
+    uint64_t div = 987654321ULL;
+    W q = a / div;
+    W r = a % div;
+    EXPECT_EQ(q * div + r, a);
+    EXPECT_EQ(wide::to_string(q), "1627024769791889844363837995440879160110719541703693");
+    EXPECT_EQ(static_cast<uint64_t>(r), 865650712ULL);
+}


### PR DESCRIPTION
## Summary
- accelerate Int256 `div_mod_small` with 128-bit batching
- use 128-bit native divide when Int256 operands fit in 128 bits
- add Int256 division unit test without Boost dependency

## Testing
- `make test`
- `build/perf_compare_int128_cxx11 --benchmark_filter=Division`


------
https://chatgpt.com/codex/tasks/task_e_68a7cc3a02448329b618df1eaa17fe95