### PR TITLE
Add int256 C++11 vs Boost benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,3 +100,14 @@ target_include_directories(perf_compare_int128_cxx11 PRIVATE
 )
 target_link_libraries(perf_compare_int128_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
 target_compile_options(perf_compare_int128_cxx11 PRIVATE -O3 -DNDEBUG)
+
+add_executable(perf_compare_int256_cxx11
+    bench/compare_int256.cpp
+)
+target_compile_definitions(perf_compare_int256_cxx11 PRIVATE USE_CXX11_HEADER)
+target_compile_features(perf_compare_int256_cxx11 PRIVATE cxx_std_11)
+target_include_directories(perf_compare_int256_cxx11 PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+target_link_libraries(perf_compare_int256_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
+target_compile_options(perf_compare_int256_cxx11 PRIVATE -O3 -DNDEBUG)

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,12 @@ test: $(BUILD_DIR)/Makefile
 
 # Build and run benchmarks
 bench: $(BUILD_DIR)/Makefile
-	cmake --build $(BUILD_DIR) --target perf_cxx17 perf_cxx11 perf_compare_int128 perf_compare_int128_cxx11
-	$(BUILD_DIR)/perf_cxx17
-	$(BUILD_DIR)/perf_cxx11
-	$(BUILD_DIR)/perf_compare_int128
-	$(BUILD_DIR)/perf_compare_int128_cxx11
+        cmake --build $(BUILD_DIR) --target perf_cxx17 perf_cxx11 perf_compare_int128 perf_compare_int128_cxx11 perf_compare_int256_cxx11
+        $(BUILD_DIR)/perf_cxx17
+        $(BUILD_DIR)/perf_cxx11
+        $(BUILD_DIR)/perf_compare_int128
+        $(BUILD_DIR)/perf_compare_int128_cxx11
+        $(BUILD_DIR)/perf_compare_int256_cxx11
 
 # Build, test and generate coverage report
 coverage: $(COVERAGE_DIR)/Makefile

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -65,3 +65,46 @@ The looped benchmark makes timing differences more visible. `wide_integer` has
 slightly faster additions than the compiler builtin or Boost types, while its
 256‑bit multiplication remains faster than Boost's implementation.
 
+## C++11 `int256` vs Boost
+
+This benchmark compares the C++11 implementation of `wide::integer<256, signed>`
+against Boost's `int256_t` for a variety of operand sizes and signs.
+
+To run:
+```bash
+cmake -S . -B build
+cmake --build build --config Release -j$(nproc)
+./build/perf_compare_int256_cxx11 --benchmark_min_time=0.01s
+```
+
+Sample output:
+```
+----------------------------------------------------------
+Benchmark                Time             CPU   Iterations
+----------------------------------------------------------
+Add/Small/Wide       0.594 ns        0.594 ns     23639169
+Add/Small/Boost       2.51 ns         2.51 ns      5522541
+Add/Large/Wide       0.587 ns        0.587 ns     23868318
+Add/Large/Boost       5.62 ns         5.62 ns      2542542
+Add/Mixed/Wide        1.18 ns         1.18 ns     11497321
+Add/Mixed/Boost       5.66 ns         5.66 ns      2500564
+Sub/Small/Wide       0.586 ns        0.586 ns     23669159
+Sub/Small/Boost       2.08 ns         2.08 ns      6677669
+Sub/Large/Wide       0.589 ns        0.589 ns     23724346
+Sub/Large/Boost       5.95 ns         5.95 ns      2312915
+Sub/Mixed/Wide       0.592 ns        0.592 ns     23616654
+Sub/Mixed/Boost       5.57 ns         5.57 ns      2502206
+Mul/Small/Wide       0.585 ns        0.585 ns     23964429
+Mul/Small/Boost       2.09 ns         2.09 ns      6831201
+Mul/Large/Wide       0.600 ns        0.600 ns     23625315
+Mul/Large/Boost       14.0 ns         14.0 ns       973061
+Mul/Mixed/Wide        2.01 ns         2.01 ns      6999199
+Mul/Mixed/Boost       15.1 ns         15.1 ns       967657
+Div/Small/Wide        14.6 ns         14.6 ns       957805
+Div/Small/Boost       10.1 ns         10.1 ns      1464733
+Div/Large/Wide         620 ns          620 ns        22840
+Div/Large/Boost       56.6 ns         56.6 ns       247870
+Div/Mixed/Wide         634 ns          634 ns        22996
+Div/Mixed/Boost       62.3 ns         62.4 ns       230513
+```
+

--- a/bench/compare_int256.cpp
+++ b/bench/compare_int256.cpp
@@ -1,0 +1,190 @@
+#include <benchmark/benchmark.h>
+#include <boost/multiprecision/cpp_int.hpp>
+
+#ifdef USE_CXX11_HEADER
+#    include <wide_integer/wide_integer_cxx11.h>
+#else
+#    include <wide_integer/wide_integer.h>
+#endif
+
+using WInt = wide::integer<256, signed>;
+using BInt = boost::multiprecision::int256_t;
+
+template <typename Int>
+static void AddSmall(benchmark::State & state)
+{
+    Int a = 1234567890123456LL;
+    Int b = 987654321098765LL;
+    for (auto _ : state)
+    {
+        auto c = a + b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void AddLarge(benchmark::State & state)
+{
+    Int a = (Int{1} << 255) - Int{1};
+    Int b = (Int{1} << 200) + Int{123456789};
+    for (auto _ : state)
+    {
+        auto c = a + b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void AddMixed(benchmark::State & state)
+{
+    Int a = (Int{1} << 200);
+    Int b = -((Int{1} << 199) + Int{1});
+    for (auto _ : state)
+    {
+        auto c = a + b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void SubSmall(benchmark::State & state)
+{
+    Int a = 9876543212345678LL;
+    Int b = 1234567890123456LL;
+    for (auto _ : state)
+    {
+        auto c = a - b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void SubLarge(benchmark::State & state)
+{
+    Int a = (Int{1} << 255) - Int{1};
+    Int b = (Int{1} << 200) + Int{12345};
+    for (auto _ : state)
+    {
+        auto c = a - b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void SubMixed(benchmark::State & state)
+{
+    Int a = -((Int{1} << 200) + Int{123});
+    Int b = (Int{1} << 199);
+    for (auto _ : state)
+    {
+        auto c = a - b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void MulSmall(benchmark::State & state)
+{
+    Int a = 123456789;
+    Int b = 987654321;
+    for (auto _ : state)
+    {
+        auto c = a * b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void MulLarge(benchmark::State & state)
+{
+    Int a = (Int{1} << 128) + Int{12345};
+    Int b = (Int{1} << 120) + Int{6789};
+    for (auto _ : state)
+    {
+        auto c = a * b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void MulMixed(benchmark::State & state)
+{
+    Int a = -((Int{1} << 128) + Int{1});
+    Int b = (Int{1} << 120);
+    for (auto _ : state)
+    {
+        auto c = a * b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void DivSmall(benchmark::State & state)
+{
+    Int a = 9876543212345678LL;
+    Int b = 123456789LL;
+    for (auto _ : state)
+    {
+        auto c = a / b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void DivLarge(benchmark::State & state)
+{
+    Int a = (Int{1} << 255) - Int{1};
+    Int b = (Int{1} << 128) + Int{12345};
+    for (auto _ : state)
+    {
+        auto c = a / b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void DivMixed(benchmark::State & state)
+{
+    Int a = -((Int{1} << 255) - Int{1});
+    Int b = (Int{1} << 128);
+    for (auto _ : state)
+    {
+        auto c = a / b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+int main(int argc, char ** argv)
+{
+    benchmark::RegisterBenchmark("Add/Small/Wide", &AddSmall<WInt>);
+    benchmark::RegisterBenchmark("Add/Small/Boost", &AddSmall<BInt>);
+    benchmark::RegisterBenchmark("Add/Large/Wide", &AddLarge<WInt>);
+    benchmark::RegisterBenchmark("Add/Large/Boost", &AddLarge<BInt>);
+    benchmark::RegisterBenchmark("Add/Mixed/Wide", &AddMixed<WInt>);
+    benchmark::RegisterBenchmark("Add/Mixed/Boost", &AddMixed<BInt>);
+
+    benchmark::RegisterBenchmark("Sub/Small/Wide", &SubSmall<WInt>);
+    benchmark::RegisterBenchmark("Sub/Small/Boost", &SubSmall<BInt>);
+    benchmark::RegisterBenchmark("Sub/Large/Wide", &SubLarge<WInt>);
+    benchmark::RegisterBenchmark("Sub/Large/Boost", &SubLarge<BInt>);
+    benchmark::RegisterBenchmark("Sub/Mixed/Wide", &SubMixed<WInt>);
+    benchmark::RegisterBenchmark("Sub/Mixed/Boost", &SubMixed<BInt>);
+
+    benchmark::RegisterBenchmark("Mul/Small/Wide", &MulSmall<WInt>);
+    benchmark::RegisterBenchmark("Mul/Small/Boost", &MulSmall<BInt>);
+    benchmark::RegisterBenchmark("Mul/Large/Wide", &MulLarge<WInt>);
+    benchmark::RegisterBenchmark("Mul/Large/Boost", &MulLarge<BInt>);
+    benchmark::RegisterBenchmark("Mul/Mixed/Wide", &MulMixed<WInt>);
+    benchmark::RegisterBenchmark("Mul/Mixed/Boost", &MulMixed<BInt>);
+
+    benchmark::RegisterBenchmark("Div/Small/Wide", &DivSmall<WInt>);
+    benchmark::RegisterBenchmark("Div/Small/Boost", &DivSmall<BInt>);
+    benchmark::RegisterBenchmark("Div/Large/Wide", &DivLarge<WInt>);
+    benchmark::RegisterBenchmark("Div/Large/Boost", &DivLarge<BInt>);
+    benchmark::RegisterBenchmark("Div/Mixed/Wide", &DivMixed<WInt>);
+    benchmark::RegisterBenchmark("Div/Mixed/Boost", &DivMixed<BInt>);
+
+    benchmark::Initialize(&argc, argv);
+    benchmark::RunSpecifiedBenchmarks();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add benchmark comparing `wide::integer<256, signed>` and Boost `int256_t` across varied operand sizes for add/sub/mul/div
- document new benchmark and sample results
- hook benchmark into build system

## Testing
- `ctest --output-on-failure`
- `./build_release/perf_compare_int256_cxx11 --benchmark_min_time=0.01s`


------
https://chatgpt.com/codex/tasks/task_e_68a7fe8528f88329996699d86119db28