### PR TITLE
Fix Makefile indentation and stabilize benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ test: $(BUILD_DIR)/Makefile
 
 # Build and run benchmarks
 bench: $(BUILD_DIR)/Makefile
-        cmake --build $(BUILD_DIR) --target perf_cxx17 perf_cxx11 perf_compare_int128 perf_compare_int128_cxx11 perf_compare_int256_cxx11
-        $(BUILD_DIR)/perf_cxx17
-        $(BUILD_DIR)/perf_cxx11
-        $(BUILD_DIR)/perf_compare_int128
-        $(BUILD_DIR)/perf_compare_int128_cxx11
-        $(BUILD_DIR)/perf_compare_int256_cxx11
+	cmake --build $(BUILD_DIR) --target perf_cxx17 perf_cxx11 perf_compare_int128 perf_compare_int128_cxx11 perf_compare_int256_cxx11
+	$(BUILD_DIR)/perf_cxx17
+	$(BUILD_DIR)/perf_cxx11
+	$(BUILD_DIR)/perf_compare_int128
+	$(BUILD_DIR)/perf_compare_int128_cxx11
+	$(BUILD_DIR)/perf_compare_int256_cxx11
 
 # Build, test and generate coverage report
 coverage: $(COVERAGE_DIR)/Makefile

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -14,51 +14,51 @@ cmake --build build --config Release -j$(nproc)
 Sample output on a 2.8 GHz CPU:
 ```
 Benchmark                            Time             CPU   Iterations
-BM_Wide128Addition                2040 ns         2038 ns       335721
-BM_Wide128Subtraction             2198 ns         2196 ns       319258
-BM_Builtin128Addition             2335 ns         2333 ns       302507
-BM_Builtin128Subtraction          2306 ns         2304 ns       302659
-BM_Wide128Multiplication           227 ns          227 ns      3106920
-BM_Wide128Division                 537 ns          536 ns      1305691
-BM_Builtin128Multiplication        232 ns          232 ns      3055719
-BM_Builtin128Division              539 ns          539 ns      1226872
-BM_Boost128Addition               2335 ns         2334 ns       302943
-BM_Boost128Subtraction            2324 ns         2323 ns       300175
-BM_Boost128Multiplication          232 ns          232 ns      3023021
-BM_Boost128Division                528 ns          528 ns      1000000
-BM_Wide256Addition                1848 ns         1847 ns       380149
-BM_Wide256Subtraction             1947 ns         1947 ns       344306
-BM_Boost256Addition               2074 ns         2072 ns       351470
-BM_Boost256Subtraction            4019 ns         4019 ns       165910
-BM_Wide256Multiplication           361 ns          361 ns      1944052
-BM_Wide256Division                4114 ns         4113 ns       136049
-BM_Boost256Multiplication          586 ns          586 ns      1202912
-BM_Boost256Division               1282 ns         1282 ns       500483
+BM_Wide128Addition                2119 ns         2119 ns       335094
+BM_Wide128Subtraction             2190 ns         2190 ns       322166
+BM_Builtin128Addition             2286 ns         2286 ns       307653
+BM_Builtin128Subtraction          2283 ns         2283 ns       306640
+BM_Wide128Multiplication           230 ns          230 ns      3061851
+BM_Wide128Division                 541 ns          541 ns      1286217
+BM_Builtin128Multiplication        226 ns          226 ns      3096622
+BM_Builtin128Division              560 ns          560 ns      1228240
+BM_Boost128Addition               2305 ns         2305 ns       305968
+BM_Boost128Subtraction            2302 ns         2302 ns       303559
+BM_Boost128Multiplication          223 ns          223 ns      3082484
+BM_Boost128Division                573 ns          573 ns      1222177
+BM_Wide256Addition                1807 ns         1807 ns       392372
+BM_Wide256Subtraction             1873 ns         1873 ns       375089
+BM_Boost256Addition               1925 ns         1925 ns       370704
+BM_Boost256Subtraction            3911 ns         3911 ns       185063
+BM_Wide256Multiplication           325 ns          325 ns      2160624
+BM_Wide256Division                1489 ns         1489 ns       474118
+BM_Boost256Multiplication          549 ns          549 ns      1300117
+BM_Boost256Division               1178 ns         1178 ns       598816
 ```
 
 Sample output for the C++11 implementation:
 ```
 Benchmark                            Time             CPU   Iterations
-BM_Wide128Addition                1965 ns         1965 ns       316455
-BM_Wide128Subtraction             2053 ns         2053 ns       345626
-BM_Builtin128Addition             2314 ns         2314 ns       292793
-BM_Builtin128Subtraction          2301 ns         2301 ns       303393
-BM_Wide128Multiplication           241 ns          241 ns      2907557
-BM_Wide128Division                 494 ns          494 ns      1290217
-BM_Builtin128Multiplication        233 ns          233 ns      3071131
-BM_Builtin128Division              568 ns          568 ns      1232465
-BM_Boost128Addition               2328 ns         2328 ns       300796
-BM_Boost128Subtraction            2326 ns         2326 ns       301175
-BM_Boost128Multiplication          232 ns          232 ns      3003255
-BM_Boost128Division                544 ns          544 ns      1285022
-BM_Wide256Addition                1993 ns         1993 ns       344203
-BM_Wide256Subtraction             2410 ns         2410 ns       319426
-BM_Boost256Addition               2059 ns         2058 ns       341676
-BM_Boost256Subtraction            4385 ns         4385 ns       163912
-BM_Wide256Multiplication           350 ns          350 ns      2004604
-BM_Wide256Division                4099 ns         4099 ns       162684
-BM_Boost256Multiplication          561 ns          561 ns      1309018
-BM_Boost256Division               1293 ns         1293 ns       561343
+BM_Wide128Addition                1837 ns         1837 ns       384807
+BM_Wide128Subtraction             4499 ns         4499 ns       151749
+BM_Builtin128Addition             2306 ns         2306 ns       300732
+BM_Builtin128Subtraction          2326 ns         2326 ns       302106
+BM_Wide128Multiplication           242 ns          242 ns      2955489
+BM_Wide128Division                 554 ns          554 ns      1262717
+BM_Builtin128Multiplication        229 ns          229 ns      3084519
+BM_Builtin128Division              571 ns          571 ns      1230586
+BM_Boost128Addition               2311 ns         2311 ns       301522
+BM_Boost128Subtraction            2311 ns         2311 ns       305205
+BM_Boost128Multiplication          227 ns          227 ns      3115710
+BM_Boost128Division                573 ns          573 ns      1227688
+BM_Wide256Addition                1902 ns         1902 ns       369321
+BM_Wide256Subtraction             2109 ns         2109 ns       333797
+BM_Boost256Addition               1948 ns         1948 ns       365818
+BM_Boost256Subtraction            4138 ns         4138 ns       165978
+BM_Wide256Multiplication           345 ns          345 ns      2039112
+BM_Wide256Division                1021 ns         1021 ns       673262
+BM_Boost256Multiplication          523 ns          523 ns      1348030
+BM_Boost256Division               1266 ns         1266 ns       588112
 ```
 
 The looped benchmark makes timing differences more visible. `wide_integer` has
@@ -82,29 +82,29 @@ Sample output:
 ----------------------------------------------------------
 Benchmark                Time             CPU   Iterations
 ----------------------------------------------------------
-Add/Small/Wide       0.594 ns        0.594 ns     23639169
-Add/Small/Boost       2.51 ns         2.51 ns      5522541
-Add/Large/Wide       0.587 ns        0.587 ns     23868318
-Add/Large/Boost       5.62 ns         5.62 ns      2542542
-Add/Mixed/Wide        1.18 ns         1.18 ns     11497321
-Add/Mixed/Boost       5.66 ns         5.66 ns      2500564
-Sub/Small/Wide       0.586 ns        0.586 ns     23669159
-Sub/Small/Boost       2.08 ns         2.08 ns      6677669
-Sub/Large/Wide       0.589 ns        0.589 ns     23724346
-Sub/Large/Boost       5.95 ns         5.95 ns      2312915
-Sub/Mixed/Wide       0.592 ns        0.592 ns     23616654
-Sub/Mixed/Boost       5.57 ns         5.57 ns      2502206
-Mul/Small/Wide       0.585 ns        0.585 ns     23964429
-Mul/Small/Boost       2.09 ns         2.09 ns      6831201
-Mul/Large/Wide       0.600 ns        0.600 ns     23625315
-Mul/Large/Boost       14.0 ns         14.0 ns       973061
-Mul/Mixed/Wide        2.01 ns         2.01 ns      6999199
-Mul/Mixed/Boost       15.1 ns         15.1 ns       967657
-Div/Small/Wide        14.6 ns         14.6 ns       957805
-Div/Small/Boost       10.1 ns         10.1 ns      1464733
-Div/Large/Wide         620 ns          620 ns        22840
-Div/Large/Boost       56.6 ns         56.6 ns       247870
-Div/Mixed/Wide         634 ns          634 ns        22996
-Div/Mixed/Boost       62.3 ns         62.4 ns       230513
+Add/Small/Wide        1.88 ns         1.88 ns    361414688
+Add/Small/Boost       2.35 ns         2.35 ns    304911624
+Add/Large/Wide        1.97 ns         1.97 ns    325738792
+Add/Large/Boost       5.05 ns         5.05 ns    100000000
+Add/Mixed/Wide        1.97 ns         1.97 ns    371788800
+Add/Mixed/Boost       6.12 ns         6.12 ns    115220534
+Sub/Small/Wide        3.05 ns         3.05 ns    237572461
+Sub/Small/Boost       2.88 ns         2.88 ns    244308597
+Sub/Large/Wide        2.95 ns         2.95 ns    228135444
+Sub/Large/Boost       7.16 ns         7.16 ns    110235512
+Sub/Mixed/Wide        3.03 ns         3.03 ns    235640889
+Sub/Mixed/Boost       5.55 ns         5.55 ns    138452880
+Mul/Small/Wide        5.04 ns         5.04 ns    116608440
+Mul/Small/Boost       2.18 ns         2.18 ns    328708300
+Mul/Large/Wide        5.31 ns         5.31 ns    132190620
+Mul/Large/Boost       14.4 ns         14.4 ns     50912489
+Mul/Mixed/Wide        5.26 ns         5.26 ns    134453355
+Mul/Mixed/Boost       15.1 ns         15.1 ns     43804318
+Div/Small/Wide        15.7 ns         15.7 ns     47161725
+Div/Small/Boost       10.2 ns         10.2 ns     70174722
+Div/Large/Wide         668 ns          668 ns      1120539
+Div/Large/Boost       58.2 ns         58.2 ns     12585309
+Div/Mixed/Wide         662 ns          662 ns      1089092
+Div/Mixed/Boost       63.5 ns         63.5 ns     11002059
 ```
 

--- a/bench/compare_int256.cpp
+++ b/bench/compare_int256.cpp
@@ -17,6 +17,8 @@ static void AddSmall(benchmark::State & state)
     Int b = 987654321098765LL;
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a + b;
         benchmark::DoNotOptimize(c);
     }
@@ -29,6 +31,8 @@ static void AddLarge(benchmark::State & state)
     Int b = (Int{1} << 200) + Int{123456789};
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a + b;
         benchmark::DoNotOptimize(c);
     }
@@ -41,6 +45,8 @@ static void AddMixed(benchmark::State & state)
     Int b = -((Int{1} << 199) + Int{1});
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a + b;
         benchmark::DoNotOptimize(c);
     }
@@ -53,6 +59,8 @@ static void SubSmall(benchmark::State & state)
     Int b = 1234567890123456LL;
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a - b;
         benchmark::DoNotOptimize(c);
     }
@@ -65,6 +73,8 @@ static void SubLarge(benchmark::State & state)
     Int b = (Int{1} << 200) + Int{12345};
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a - b;
         benchmark::DoNotOptimize(c);
     }
@@ -77,6 +87,8 @@ static void SubMixed(benchmark::State & state)
     Int b = (Int{1} << 199);
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a - b;
         benchmark::DoNotOptimize(c);
     }
@@ -89,6 +101,8 @@ static void MulSmall(benchmark::State & state)
     Int b = 987654321;
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a * b;
         benchmark::DoNotOptimize(c);
     }
@@ -101,6 +115,8 @@ static void MulLarge(benchmark::State & state)
     Int b = (Int{1} << 120) + Int{6789};
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a * b;
         benchmark::DoNotOptimize(c);
     }
@@ -113,6 +129,8 @@ static void MulMixed(benchmark::State & state)
     Int b = (Int{1} << 120);
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a * b;
         benchmark::DoNotOptimize(c);
     }
@@ -125,6 +143,8 @@ static void DivSmall(benchmark::State & state)
     Int b = 123456789LL;
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a / b;
         benchmark::DoNotOptimize(c);
     }
@@ -137,6 +157,8 @@ static void DivLarge(benchmark::State & state)
     Int b = (Int{1} << 128) + Int{12345};
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a / b;
         benchmark::DoNotOptimize(c);
     }
@@ -149,6 +171,8 @@ static void DivMixed(benchmark::State & state)
     Int b = (Int{1} << 128);
     for (auto _ : state)
     {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
         auto c = a / b;
         benchmark::DoNotOptimize(c);
     }


### PR DESCRIPTION
## Summary
- Replace spaces with tabs in Makefile's bench target
- Prevent constant folding in int256 C++11 benchmarks by guarding inputs
- Update benchmark documentation with fresh results

## Testing
- `make test`
- `make bench`


------
https://chatgpt.com/codex/tasks/task_e_68a8041b6d788329ae4ed24ee18c9c27