### PR TITLE
Correct numeric_limits friend declaration for C++11

### DIFF
--- a/include/wide_integer/wide_integer_cxx11.h
+++ b/include/wide_integer/wide_integer_cxx11.h
@@ -246,8 +246,7 @@ public:
     using limb_type = uint64_t;
     template <size_t>
     friend struct detail::limbs_equal;
-    template <size_t, typename>
-    friend class std::numeric_limits;
+    friend class std::numeric_limits<integer<Bits, Signed>>;
 
     constexpr integer() noexcept = default;
 


### PR DESCRIPTION
## Summary
- fix std::numeric_limits friend declaration in the C++11 wide integer implementation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a8749cace08329a8767c70d59f7a74