### PR TITLE
ci: add macOS and benchmark jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,30 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake build-essential clang-format libfmt-dev libgtest-dev libbenchmark-dev lcov libboost-dev
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y cmake build-essential clang-format \
+              libfmt-dev libgtest-dev lcov libboost-dev
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew update
+            brew install cmake clang-format fmt googletest boost
+          fi
       - name: Configure
-        run: cmake -S . -B build -DENABLE_COVERAGE=ON
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            cmake -S . -B build -DENABLE_COVERAGE=ON -DWI_BUILD_TESTS=ON -DWI_BUILD_BENCHMARKS=OFF
+          else
+            cmake -S . -B build -DWI_BUILD_TESTS=ON -DWI_BUILD_BENCHMARKS=OFF
+          fi
       - name: Build
         run: cmake --build build --config Debug
       - name: Run tests
@@ -22,6 +37,7 @@ jobs:
           cd build
           ctest --output-on-failure
       - name: Generate coverage
+        if: matrix.os == 'ubuntu-latest'
         run: |
           lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch
           lcov --remove coverage.info '/usr/*' '*/tests/*' --output-file coverage.info
@@ -34,3 +50,20 @@ jobs:
             git diff --exit-code
           fi
 
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential libfmt-dev libbenchmark-dev libboost-dev
+      - name: Configure
+        run: cmake -S . -B build -DWI_BUILD_TESTS=OFF -DWI_BUILD_BENCHMARKS=ON
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Run benchmarks
+        run: |
+          build/perf_cxx17 --benchmark_min_time=0.01s
+          build/perf_cxx11 --benchmark_min_time=0.01s
+          build/perf_compare_int256_cxx11 --benchmark_min_time=0.01s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wide_integer LANGUAGES CXX)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 option(ENABLE_COVERAGE "Enable coverage reporting" OFF)
+option(WI_BUILD_TESTS "Build test suite" ON)
+option(WI_BUILD_BENCHMARKS "Build benchmarks" OFF)
 
 set(WI_TEST_OPTIONS -O0 -g)
 set(WI_TEST_LINK_OPTIONS "")
@@ -22,8 +24,6 @@ if(NOT fmt_FOUND)
     pkg_check_modules(fmt REQUIRED IMPORTED_TARGET fmt)
     add_library(fmt::fmt ALIAS PkgConfig::fmt)
 endif()
-find_package(GTest REQUIRED)
-find_package(benchmark REQUIRED)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
@@ -37,88 +37,93 @@ target_include_directories(wide_integer INTERFACE
 
 target_compile_features(wide_integer INTERFACE cxx_std_17)
 
-enable_testing()
-include(GoogleTest)
-function(add_wide_test name source std)
-    add_executable(${name} ${source})
-    target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-    set_target_properties(${name} PROPERTIES CXX_STANDARD ${std} CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS YES)
-    target_compile_options(${name} PRIVATE ${WI_TEST_OPTIONS})
-    if(WI_TEST_LINK_OPTIONS)
-        target_link_options(${name} PRIVATE ${WI_TEST_LINK_OPTIONS})
-    endif()
-    target_link_libraries(${name} PRIVATE GTest::gtest_main)
-    gtest_discover_tests(${name} NO_PRETTY_VALUES)
-endfunction()
+if(WI_BUILD_TESTS)
+    find_package(GTest REQUIRED)
+    enable_testing()
+    include(GoogleTest)
+    function(add_wide_test name source std)
+        add_executable(${name} ${source})
+        target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+        set_target_properties(${name} PROPERTIES CXX_STANDARD ${std} CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS YES)
+        target_compile_options(${name} PRIVATE ${WI_TEST_OPTIONS})
+        if(WI_TEST_LINK_OPTIONS)
+            target_link_options(${name} PRIVATE ${WI_TEST_LINK_OPTIONS})
+        endif()
+        target_link_libraries(${name} PRIVATE GTest::gtest_main)
+        gtest_discover_tests(${name} NO_PRETTY_VALUES)
+    endfunction()
 
-add_wide_test(wide_integer_test tests/wide_integer_test.cpp 17)
-target_link_libraries(wide_integer_test PRIVATE fmt::fmt)
-add_wide_test(wide_integer_cxx11_test tests/wide_integer_test.cpp 11)
-target_compile_definitions(wide_integer_cxx11_test PRIVATE USE_CXX11_HEADER)
-target_link_libraries(wide_integer_cxx11_test PRIVATE fmt::fmt)
+    add_wide_test(wide_integer_test tests/wide_integer_test.cpp 17)
+    target_link_libraries(wide_integer_test PRIVATE fmt::fmt)
+    add_wide_test(wide_integer_cxx11_test tests/wide_integer_test.cpp 11)
+    target_compile_definitions(wide_integer_cxx11_test PRIVATE USE_CXX11_HEADER)
+    target_link_libraries(wide_integer_cxx11_test PRIVATE fmt::fmt)
+endif()
 
+if(WI_BUILD_BENCHMARKS)
+    find_package(benchmark REQUIRED)
 
-add_executable(perf_cxx17
-    bench/performance.cpp
-)
-target_include_directories(perf_cxx17 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-target_compile_features(perf_cxx17 PRIVATE cxx_std_17)
-target_link_libraries(perf_cxx17 PRIVATE fmt::fmt benchmark::benchmark)
-target_compile_options(perf_cxx17 PRIVATE -O3 -DNDEBUG)
+    add_executable(perf_cxx17
+        bench/performance.cpp
+    )
+    target_include_directories(perf_cxx17 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_compile_features(perf_cxx17 PRIVATE cxx_std_17)
+    target_link_libraries(perf_cxx17 PRIVATE fmt::fmt benchmark::benchmark)
+    target_compile_options(perf_cxx17 PRIVATE -O3 -DNDEBUG)
 
+    add_executable(perf_cxx11
+        bench/performance.cpp
+    )
+    target_compile_definitions(perf_cxx11 PRIVATE USE_CXX11_HEADER)
+    target_include_directories(perf_cxx11 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_compile_features(perf_cxx11 PRIVATE cxx_std_11)
+    target_link_libraries(perf_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
+    target_compile_options(perf_cxx11 PRIVATE -O3 -DNDEBUG)
 
-add_executable(perf_cxx11
-    bench/performance.cpp
-)
-target_compile_definitions(perf_cxx11 PRIVATE USE_CXX11_HEADER)
-target_include_directories(perf_cxx11 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-target_compile_features(perf_cxx11 PRIVATE cxx_std_11)
-target_link_libraries(perf_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
-target_compile_options(perf_cxx11 PRIVATE -O3 -DNDEBUG)
+    add_executable(perf_compare_int128
+        bench/compare_int128.cpp
+    )
+    target_compile_features(perf_compare_int128 PRIVATE cxx_std_17)
+    target_include_directories(perf_compare_int128 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(perf_compare_int128 PRIVATE wide_integer fmt::fmt benchmark::benchmark)
+    target_compile_options(perf_compare_int128 PRIVATE -O3 -DNDEBUG)
 
-add_executable(perf_compare_int128
-    bench/compare_int128.cpp
-)
-target_compile_features(perf_compare_int128 PRIVATE cxx_std_17)
-target_include_directories(perf_compare_int128 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-target_link_libraries(perf_compare_int128 PRIVATE wide_integer fmt::fmt benchmark::benchmark)
-target_compile_options(perf_compare_int128 PRIVATE -O3 -DNDEBUG)
+    add_executable(perf_compare_int128_cxx11
+        bench/compare_int128.cpp
+    )
+    target_compile_definitions(perf_compare_int128_cxx11 PRIVATE USE_CXX11_HEADER)
+    target_compile_features(perf_compare_int128_cxx11 PRIVATE cxx_std_11)
+    target_include_directories(perf_compare_int128_cxx11 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(perf_compare_int128_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
+    target_compile_options(perf_compare_int128_cxx11 PRIVATE -O3 -DNDEBUG)
 
-add_executable(perf_compare_int128_cxx11
-    bench/compare_int128.cpp
-)
-target_compile_definitions(perf_compare_int128_cxx11 PRIVATE USE_CXX11_HEADER)
-target_compile_features(perf_compare_int128_cxx11 PRIVATE cxx_std_11)
-target_include_directories(perf_compare_int128_cxx11 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-target_link_libraries(perf_compare_int128_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
-target_compile_options(perf_compare_int128_cxx11 PRIVATE -O3 -DNDEBUG)
+    add_executable(perf_compare_int256_cxx11
+        bench/compare_int256.cpp
+    )
+    target_compile_definitions(perf_compare_int256_cxx11 PRIVATE USE_CXX11_HEADER)
+    target_compile_features(perf_compare_int256_cxx11 PRIVATE cxx_std_11)
+    target_include_directories(perf_compare_int256_cxx11 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(perf_compare_int256_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
+    target_compile_options(perf_compare_int256_cxx11 PRIVATE -O3 -DNDEBUG)
 
-add_executable(perf_compare_int256_cxx11
-    bench/compare_int256.cpp
-)
-target_compile_definitions(perf_compare_int256_cxx11 PRIVATE USE_CXX11_HEADER)
-target_compile_features(perf_compare_int256_cxx11 PRIVATE cxx_std_11)
-target_include_directories(perf_compare_int256_cxx11 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-target_link_libraries(perf_compare_int256_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
-target_compile_options(perf_compare_int256_cxx11 PRIVATE -O3 -DNDEBUG)
-
-add_executable(perf_compare_int256_random_cxx11
-    bench/compare_int256_random.cpp
-)
-target_compile_definitions(perf_compare_int256_random_cxx11 PRIVATE USE_CXX11_HEADER)
-target_compile_features(perf_compare_int256_random_cxx11 PRIVATE cxx_std_11)
-target_include_directories(perf_compare_int256_random_cxx11 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-target_link_libraries(perf_compare_int256_random_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
-target_compile_options(perf_compare_int256_random_cxx11 PRIVATE -O3 -DNDEBUG)
+    add_executable(perf_compare_int256_random_cxx11
+        bench/compare_int256_random.cpp
+    )
+    target_compile_definitions(perf_compare_int256_random_cxx11 PRIVATE USE_CXX11_HEADER)
+    target_compile_features(perf_compare_int256_random_cxx11 PRIVATE cxx_std_11)
+    target_include_directories(perf_compare_int256_random_cxx11 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(perf_compare_int256_random_cxx11 PRIVATE fmt::fmt benchmark::benchmark)
+    target_compile_options(perf_compare_int256_random_cxx11 PRIVATE -O3 -DNDEBUG)
+endif()

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,38 @@
-BUILD_DIR ?= build
+TEST_BUILD_DIR ?= build
+BENCH_BUILD_DIR ?= build-bench
 COVERAGE_DIR ?= build-coverage
 
 .PHONY: test bench coverage clean
 
-$(BUILD_DIR)/Makefile:
-	cmake -S . -B $(BUILD_DIR)
+$(TEST_BUILD_DIR)/Makefile:
+        cmake -S . -B $(TEST_BUILD_DIR) -DWI_BUILD_TESTS=ON -DWI_BUILD_BENCHMARKS=OFF
+
+$(BENCH_BUILD_DIR)/Makefile:
+        cmake -S . -B $(BENCH_BUILD_DIR) -DWI_BUILD_TESTS=OFF -DWI_BUILD_BENCHMARKS=ON
 
 $(COVERAGE_DIR)/Makefile:
-	cmake -S . -B $(COVERAGE_DIR) -DENABLE_COVERAGE=ON
+        cmake -S . -B $(COVERAGE_DIR) -DENABLE_COVERAGE=ON -DWI_BUILD_TESTS=ON -DWI_BUILD_BENCHMARKS=OFF
 
 # Build and run unit tests
-test: $(BUILD_DIR)/Makefile
-	cmake --build $(BUILD_DIR)
-	cd $(BUILD_DIR) && ctest --output-on-failure
+test: $(TEST_BUILD_DIR)/Makefile
+        cmake --build $(TEST_BUILD_DIR)
+        cd $(TEST_BUILD_DIR) && ctest --output-on-failure
 
 # Build and run benchmarks
-bench: $(BUILD_DIR)/Makefile
-	cmake --build $(BUILD_DIR) --target perf_cxx17 perf_cxx11 perf_compare_int128 perf_compare_int128_cxx11 perf_compare_int256_cxx11 perf_compare_int256_random_cxx11
-	$(BUILD_DIR)/perf_cxx17
-	$(BUILD_DIR)/perf_cxx11
-	$(BUILD_DIR)/perf_compare_int128
-	$(BUILD_DIR)/perf_compare_int128_cxx11
-	$(BUILD_DIR)/perf_compare_int256_cxx11
-	$(BUILD_DIR)/perf_compare_int256_random_cxx11
+bench: $(BENCH_BUILD_DIR)/Makefile
+	cmake --build $(BENCH_BUILD_DIR)
+	$(BENCH_BUILD_DIR)/perf_cxx17
+	$(BENCH_BUILD_DIR)/perf_cxx11
+	$(BENCH_BUILD_DIR)/perf_compare_int256_cxx11
 
 # Build, test and generate coverage report
 coverage: $(COVERAGE_DIR)/Makefile
-	cmake --build $(COVERAGE_DIR) --config Debug
-	cd $(COVERAGE_DIR) && ctest --output-on-failure
-	lcov --capture --directory $(COVERAGE_DIR) --output-file $(COVERAGE_DIR)/coverage.info --ignore-errors mismatch
-	lcov --remove $(COVERAGE_DIR)/coverage.info '/usr/*' '*/tests/*' --output-file $(COVERAGE_DIR)/coverage.info
-	lcov --list $(COVERAGE_DIR)/coverage.info
+        cmake --build $(COVERAGE_DIR) --config Debug
+        cd $(COVERAGE_DIR) && ctest --output-on-failure
+        lcov --capture --directory $(COVERAGE_DIR) --output-file $(COVERAGE_DIR)/coverage.info --ignore-errors mismatch
+        lcov --remove $(COVERAGE_DIR)/coverage.info '/usr/*' '*/tests/*' --output-file $(COVERAGE_DIR)/coverage.info
+        lcov --list $(COVERAGE_DIR)/coverage.info
 
 # Remove build directories
 clean:
-	rm -rf $(BUILD_DIR) $(COVERAGE_DIR)
+        rm -rf $(TEST_BUILD_DIR) $(BENCH_BUILD_DIR) $(COVERAGE_DIR)


### PR DESCRIPTION
## Summary
- add configurable switches to build tests or benchmarks separately
- split Makefile targets for tests and benchmarks
- run tests on Linux and macOS (without coverage on macOS) and add Linux-only benchmark job
- drop unused CI dependencies and limit benchmark runs to perf_cxx17, perf_cxx11, and perf_compare_int256_cxx11
- install Boost for test builds on both Linux and macOS

## Testing
- `cmake -S . -B build -DENABLE_COVERAGE=ON -DWI_BUILD_TESTS=ON -DWI_BUILD_BENCHMARKS=OFF`
- `cmake --build build --config Debug`
- `cd build && ctest --output-on-failure`
- `lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch`
- `lcov --remove coverage.info '/usr/*' '*/tests/*' --output-file coverage.info`
- `lcov --list coverage.info | head -n 20`
- `cmake -S . -B build-bench -DWI_BUILD_TESTS=OFF -DWI_BUILD_BENCHMARKS=ON`
- `cmake --build build-bench --config Release`
- `build-bench/perf_cxx17 --benchmark_min_time=0.01s`
- `build-bench/perf_cxx11 --benchmark_min_time=0.01s`
- `build-bench/perf_compare_int256_cxx11 --benchmark_min_time=0.01s`


------
https://chatgpt.com/codex/tasks/task_e_68a8781b07a88329ad42581cc367284e