### PR TITLE
Add benchmark workflow with PR summary

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,25 @@
+name: Benchmark
+
+on:
+  pull_request:
+
+jobs:
+  perf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential libfmt-dev libbenchmark-dev libboost-dev jq
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Build benchmark
+        run: cmake --build build --target perf_compare_int256_cxx11
+      - name: Run benchmark
+        run: build/perf_compare_int256_cxx11 --benchmark_min_time=0.01s --benchmark_time_unit=ns --benchmark_format=json > perf.json
+      - name: Post results
+        run: |
+          echo "| Benchmark | Real time (ns) | CPU time (ns) | Iterations |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- | --- | --- |" >> $GITHUB_STEP_SUMMARY
+          jq -r '.benchmarks[] | "| \(.name) | " + ((.real_time*100|round/100)|tostring) + " | " + ((.cpu_time*100|round/100)|tostring) + " | \(.iterations) |"' perf.json >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- run perf_compare_int256_cxx11 in CI and convert its results into a table shown in the PR summary

## Testing
- `cmake -S . -B build && cmake --build build --config Debug && cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a884ce31e48329a233177c22141f6a