### PR TITLE
Fix Makefile recipe indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,18 @@ COVERAGE_DIR ?= build-coverage
 .PHONY: test bench coverage clean
 
 $(TEST_BUILD_DIR)/Makefile:
-        cmake -S . -B $(TEST_BUILD_DIR) -DWI_BUILD_TESTS=ON -DWI_BUILD_BENCHMARKS=OFF
+	cmake -S . -B $(TEST_BUILD_DIR) -DWI_BUILD_TESTS=ON -DWI_BUILD_BENCHMARKS=OFF
 
 $(BENCH_BUILD_DIR)/Makefile:
-        cmake -S . -B $(BENCH_BUILD_DIR) -DWI_BUILD_TESTS=OFF -DWI_BUILD_BENCHMARKS=ON
+	cmake -S . -B $(BENCH_BUILD_DIR) -DWI_BUILD_TESTS=OFF -DWI_BUILD_BENCHMARKS=ON
 
 $(COVERAGE_DIR)/Makefile:
-        cmake -S . -B $(COVERAGE_DIR) -DENABLE_COVERAGE=ON -DWI_BUILD_TESTS=ON -DWI_BUILD_BENCHMARKS=OFF
+	cmake -S . -B $(COVERAGE_DIR) -DENABLE_COVERAGE=ON -DWI_BUILD_TESTS=ON -DWI_BUILD_BENCHMARKS=OFF
 
 # Build and run unit tests
 test: $(TEST_BUILD_DIR)/Makefile
-        cmake --build $(TEST_BUILD_DIR)
-        cd $(TEST_BUILD_DIR) && ctest --output-on-failure
+	cmake --build $(TEST_BUILD_DIR)
+	cd $(TEST_BUILD_DIR) && ctest --output-on-failure
 
 # Build and run benchmarks
 bench: $(BENCH_BUILD_DIR)/Makefile
@@ -27,12 +27,12 @@ bench: $(BENCH_BUILD_DIR)/Makefile
 
 # Build, test and generate coverage report
 coverage: $(COVERAGE_DIR)/Makefile
-        cmake --build $(COVERAGE_DIR) --config Debug
-        cd $(COVERAGE_DIR) && ctest --output-on-failure
-        lcov --capture --directory $(COVERAGE_DIR) --output-file $(COVERAGE_DIR)/coverage.info --ignore-errors mismatch
-        lcov --remove $(COVERAGE_DIR)/coverage.info '/usr/*' '*/tests/*' --output-file $(COVERAGE_DIR)/coverage.info
-        lcov --list $(COVERAGE_DIR)/coverage.info
+	cmake --build $(COVERAGE_DIR) --config Debug
+	cd $(COVERAGE_DIR) && ctest --output-on-failure
+	lcov --capture --directory $(COVERAGE_DIR) --output-file $(COVERAGE_DIR)/coverage.info --ignore-errors mismatch
+	lcov --remove $(COVERAGE_DIR)/coverage.info '/usr/*' '*/tests/*' --output-file $(COVERAGE_DIR)/coverage.info
+	lcov --list $(COVERAGE_DIR)/coverage.info
 
 # Remove build directories
 clean:
-        rm -rf $(TEST_BUILD_DIR) $(BENCH_BUILD_DIR) $(COVERAGE_DIR)
+	rm -rf $(TEST_BUILD_DIR) $(BENCH_BUILD_DIR) $(COVERAGE_DIR)


### PR DESCRIPTION
## Summary
- enforce tab indentation in Makefile recipes

## Testing
- `FILES=$(git ls-files '*.cpp' '*.hpp' '*.h'); if [ -n "$FILES" ]; then clang-format -i --style=file $FILES; git diff --exit-code; fi`
- `cmake -S . -B build -DWI_BUILD_TESTS=ON -DWI_BUILD_BENCHMARKS=OFF`
- `cmake --build build --config Debug`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a888fedb988329bf38b740e6a3bf33